### PR TITLE
use the baseURL to determine random and home page

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/">Home</a>
+      <a class="navbar-brand" href="{{ "" | absURL }}">Home</a>
     </div>
 
     <!-- Collect the nav links, forms, and other content for toggling -->
@@ -26,7 +26,7 @@
             {{ end }}
           </ul>
         </li>
-        <li><a href="/random/">Random</a></li>
+        <li><a href="{{ "random" | absURL }}">Random</a></li>
         {{ with $.Site.Data.meta.search }}
           <li><a href="{{ . }}">Search</a></li>
         {{ end }}


### PR DESCRIPTION
Currently the navbar has hardcoded links to the `random` and home page. This PR will have it use the `baseURL` setting to determine the correct link.

This is mainly useful if you host the site in a sub-directory instead of on the root of the domain.